### PR TITLE
Remove GET_VR_DISPLAYS_TIMEOUT since it can lead to false positives

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -42,15 +42,6 @@ export default {
   // Added in 0.10.0.
   PROVIDE_MOBILE_VRDISPLAY: true,
 
-  // There are versions of Chrome (M58-M60?) where the native WebVR API exists,
-  // and instead of returning 0 VR displays when none are detected,
-  // `navigator.getVRDisplays()`'s promise never resolves. This results
-  // in the polyfill hanging and not being able to provide fallback
-  // displays, so set a timeout in milliseconds to stop waiting for a response
-  // and just use polyfilled displays.
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=727969
-  GET_VR_DISPLAYS_TIMEOUT: 1000,
-
   /**
    * Options passed into the underlying CardboardVRDisplay
    */

--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -129,22 +129,7 @@ WebVRPolyfill.prototype.getVRDisplays = function() {
     return Promise.resolve(this.getPolyfillDisplays());
   }
 
-  // Set up a race condition if this browser has a bug where
-  // `navigator.getVRDisplays()` never resolves.
-  var timeoutId;
-  var vrDisplaysNative = this.native.getVRDisplays.call(navigator);
-  var timeoutPromise = new Promise(function(resolve) {
-    timeoutId = setTimeout(function() {
-      console.warn('Native WebVR implementation detected, but `getVRDisplays()` failed to resolve. Falling back to polyfill.');
-      resolve([]);
-    }, config.GET_VR_DISPLAYS_TIMEOUT);
-  });
-
-  return race([
-    vrDisplaysNative,
-    timeoutPromise
-  ]).then(nativeDisplays => {
-    clearTimeout(timeoutId);
+  return this.native.getVRDisplays.call(navigator).then((nativeDisplays) => {
     return nativeDisplays.length > 0 ? nativeDisplays : this.getPolyfillDisplays();
   });
 };


### PR DESCRIPTION
 and Chrome 58-60 are no longer in reasonable circulation. Fixes #335

@Artyom17 can you try this out and see if it works for you on Oculus?

